### PR TITLE
json to yml

### DIFF
--- a/.sass-lint.yml
+++ b/.sass-lint.yml
@@ -95,8 +95,7 @@ rules:
     no-url-protocols: 0
     no-vendor-prefixes:
         - 1
-        - additional-identifiers: []
-          excluded-identifiers: []
+        - ignore-non-standard: true
     no-warn: 0
     one-declaration-per-line: 1
     placeholder-in-extend: 0

--- a/.sass-lint.yml
+++ b/.sass-lint.yml
@@ -102,7 +102,6 @@ rules:
     placeholder-name-format:
         - 0
         - convention: hyphenatedlowercase
-
     property-sort-order:
         - 0
         - ignore-custom-properties: false

--- a/.scsslintrc
+++ b/.scsslintrc
@@ -1,263 +1,156 @@
-{
-    "files": {
-        "include": "**/*.scss"
-    },
-    "options": {
-        "formatter": "stylish",
-        "merge-default-rules": false
-    },
-    "rules": {
-        "attribute-quotes": [
-            1,
-            {
-                "include": true
-            }
-        ],
-        "bem-depth": [
-            1,
-            {
-                "max-depth": 1
-            }
-        ],
-        "border-zero": [
-            1,
-            {
-                "convention": "0"
-            }
-        ],
-        "brace-style": [
-            1,
-            {
-                "style": "1tbs",
-                "allow-single-line": false
-            }
-        ],
-        "class-name-format": [
-            1,
-            {
-                "allow-leading-underscore": false,
-                "convention": "hyphenatedbem"
-            }
-        ],
-        "clean-import-paths": [
-            1,
-            {
-                "leading-underscore": false,
-                "filename-extension": false
-            }
-        ],
-        "empty-args": 0,
-        "empty-line-between-blocks": [
-            1,
-            {
-                "include": true,
-                "allow-single-line-rulesets": true
-            }
-        ],
-        "extends-before-declarations": 0,
-        "extends-before-mixins": 0,
-        "final-newline": [
-            1,
-            {
-                "include": true
-            }
-        ],
-        "force-attribute-nesting": 0,
-        "force-element-nesting": 0,
-        "force-pseudo-nesting": 0,
-        "function-name-format": [
-            1,
-            {
-                "allow-leading-underscore": false,
-                "convention": "hyphenatedlowercase"
-            }
-        ],
-        "hex-length": [
-            1,
-            {
-                "style": "short"
-            }
-        ],
-        "hex-notation": [
-            1,
-            {
-                "style": "lowercase"
-            }
-        ],
-        "id-name-format": 0,
-        "indentation": [
-            1,
-            {
-                "size": 4
-            }
-        ],
-        "leading-zero": [
-            1,
-            {
-                "include": true
-            }
-        ],
-        "mixin-name-format": [
-            1,
-            {
-                "allow-leading-underscore": false,
-                "convention": "hyphenatedlowercase"
-            }
-        ],
-        "mixins-before-declarations": 1,
-        "nesting-depth": [
-            1,
-            {
-                "max-depth": 2
-            }
-        ],
-        "no-attribute-selectors": 0,
-        "no-color-keywords": 1,
-        "no-color-literals": [
-            1,
-            {
-                "allow-map-identifiers": true,
-                "allow-rgba": true,
-                "allow-variable-identifiers": true
-            }
-        ],
-        "no-combinators": 0,
-        "no-css-comments": 1,
-        "no-debug": 1,
-        "no-disallowed-properties": 0,
-        "no-duplicate-properties": 0,
-        "no-empty-rulesets": 1,
-        "no-extends": 1,
-        "no-ids": 2,
-        "no-important": 0,
-        "no-invalid-hex": 1,
-        "no-mergeable-selectors": 0,
-        "no-misspelled-properties": [
-            1,
-            {
-                "extra-properties": []
-            }
-        ],
-        "no-qualifying-elements": [
-            1,
-            {
-                "allow-element-with-attribute": false,
-                "allow-element-with-class": false,
-                "allow-element-with-id": false
-            }
-        ],
-        "no-trailing-zero": 1,
-        "no-transition-all": 1,
-        "no-universal-selectors": 0,
-        "no-url-protocols": 0,
-        "no-vendor-prefixes": [
-            1,
-            {
-                "additional-identifiers": [],
-                "excluded-identifiers": []
-            }
-        ],
-        "no-warn": 0,
-        "one-declaration-per-line": 1,
-        "placeholder-in-extend": 0,
-        "placeholder-name-format": [
-            0,
-            {
-                "convention": "hyphenatedlowercase"
-            }
-        ],
-        "property-sort-order": [
-            0,
-            {
-                "ignore-custom-properties": false
-            }
-        ],
-        "property-units": 0,
-        "quotes": [
-            1,
-            {
-                "style": "single"
-            }
-        ],
-        "shorthand-values": [
-            1,
-            {
-                "allowed-shorthands": [
-                    1,
-                    2,
-                    3
-                ]
-            }
-        ],
-        "single-line-per-selector": 1,
-        "space-after-bang": [
-            1,
-            {
-                "include": false
-            }
-        ],
-        "space-after-colon": [
-            1,
-            {
-                "include": true
-            }
-        ],
-        "space-after-comma": [
-            1,
-            {
-                "include": true
-            }
-        ],
-        "space-around-operator": [
-            1,
-            {
-                "include": true
-            }
-        ],
-        "space-before-bang": [
-            1,
-            {
-                "include": true
-            }
-        ],
-        "space-before-brace": [
-            1,
-            {
-                "include": true
-            }
-        ],
-        "space-before-colon": [
-            1,
-            {
-                "include": false
-            }
-        ],
-        "space-between-parens": [
-            1,
-            {
-                "include": false
-            }
-        ],
-        "trailing-semicolon": [
-            1,
-            {
-                "include": true
-            }
-        ],
-        "url-quotes": 1,
-        "variable-for-property": 0,
-        "variable-name-format": [
-            1,
-            {
-                "allow-leading-underscore": false,
-                "convention": "hyphenatedlowercase"
-            }
-        ],
-        "zero-unit": [
-            1,
-            {
-                "include": false
-            }
-        ]
-    }
-}
+files:
+  include: '**/*.scss'
+options:
+  formatter: stylish
+  merge-default-rules: false
+rules:
+    attribute-quotes:
+        - 1
+        - include: true
+    bem-depth:
+        - 1
+        - max-depth: 1
+    border-zero:
+        - 1
+        - convention: 0
+    brace-style:
+        - 1
+        - style: '1tbs'
+          allow-single-line: false
+    class-name-format:
+        - 1
+        - allow-leading-underscore: false
+          convention: hyphenatedbem
+    clean-import-paths:
+        - 1
+        - leading-underscore: false
+          filename-extension: false
+    empty-args: 0
+    empty-line-between-blocks:
+        - 1
+        - include: true
+          allow-single-line-rulesets: true
+    extends-before-declarations: 0
+    extends-before-mixins: 0
+    final-newline:
+        - 1
+        - include: true
+    force-attribute-nesting: 0
+    force-element-nesting: 0
+    force-pseudo-nesting: 0
+    function-name-format:
+        - 1
+        - allow-leading-underscore: false
+          convention: hyphenatedlowercase
+    hex-length:
+        - 1
+        - style: short
+    hex-notation:
+        - 1
+        - style: lowercase
+    id-name-format: 0
+    indentation:
+        - 1
+        - size: 4
+    leading-zero:
+        - 1
+        - include: true
+    mixin-name-format:
+        - 1
+        - allow-leading-underscore: false
+          convention: hyphenatedlowercase
+    mixins-before-declarations: 1
+    nesting-depth:
+        - 1
+        - max-depth: 2
+    no-attribute-selectors: 0
+    no-color-keywords: 1
+    no-color-literals:
+        - 1
+        - allow-map-identifiers: true
+          allow-rgba: true
+          allow-variable-identifiers: true
+    no-combinators: 0
+    no-css-comments: 1
+    no-debug: 1
+    no-disallowed-properties: 0
+    no-duplicate-properties: 0
+    no-empty-rulesets: 1
+    no-extends: 1
+    no-ids: 2
+    no-important: 0
+    no-invalid-hex: 1
+    no-mergeable-selectors: 0
+    no-misspelled-properties:
+        - 1
+        - extra-properties: []
+    no-qualifying-elements:
+        - 1
+        - allow-element-with-attribute: false
+          allow-element-with-class: false
+          allow-element-with-id: false
+    no-trailing-zero: 1
+    no-transition-all: 1
+    no-universal-selectors: 0
+    no-url-protocols: 0
+    no-vendor-prefixes:
+        - 1
+        - additional-identifiers: []
+          excluded-identifiers: []
+    no-warn: 0
+    one-declaration-per-line: 1
+    placeholder-in-extend: 0
+    placeholder-name-format:
+        - 0
+        - convention: hyphenatedlowercase
+
+    property-sort-order:
+        - 0
+        - ignore-custom-properties: false
+    property-units: 0
+    quotes:
+        - 1
+        - style: single
+    shorthand-values:
+        - 1
+        - allowed-shorthands:
+            - 1
+            - 2
+            - 3
+    single-line-per-selector: 1
+    space-after-bang:
+        - 1
+        - include: false
+    space-after-colon:
+        - 1
+        - include: true
+    space-after-comma:
+        - 1
+        - include: true
+    space-around-operator:
+        - 1
+        - include: true
+    space-before-bang:
+        - 1
+        - include: true
+    space-before-brace:
+        - 1
+        - include: true
+    space-before-colon:
+        - 1
+        - include: false
+    space-between-parens:
+        - 1
+        - include: false
+    trailing-semicolon:
+        - 1
+        - include: true
+    url-quotes: 1
+    variable-for-property: 0
+    variable-name-format:
+        - 1
+        - allow-leading-underscore: false
+          convention: hyphenatedlowercase
+    zero-unit:
+        - 1
+        - include: false

--- a/.scsslintrc
+++ b/.scsslintrc
@@ -1,8 +1,8 @@
 files:
-  include: '**/*.scss'
+    include: '**/*.scss'
 options:
-  formatter: stylish
-  merge-default-rules: false
+    formatter: stylish
+    merge-default-rules: false
 rules:
     attribute-quotes:
         - 1


### PR DESCRIPTION
Changed syntax of linter config file, from json to yml, for compatibility reasons with text editors.
Config remains exactly the same.